### PR TITLE
Add language streams to dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -1136,6 +1136,10 @@
                                 <input type="range" id="volume-slider" min="0" max="1" step="0.01" value="0.5" class="volume-slider">
                             </div>
                             <div class="radio-dropdown">
+                                <button id="language-select-btn" class="radio-dropdown-btn">Select Language <i class="fas fa-chevron-up"></i></button>
+                                <div id="language-select-options" class="radio-dropdown-options"></div>
+                            </div>
+                            <div class="radio-dropdown">
                                 <button id="station-select-btn" class="radio-dropdown-btn">Select Station <i class="fas fa-chevron-up"></i></button>
                                 <div id="station-select-options" class="radio-dropdown-options"></div>
                             </div>
@@ -1331,6 +1335,9 @@
         const screensaverDisplay = document.getElementById('screensaver-display');
         // NEWS TICKER DOM ELEMENT - NEW
         const newsTicker = document.getElementById('news-ticker');
+        // Language selector DOM elements - NEW
+        const languageSelectBtn = document.getElementById('language-select-btn');
+        const languageSelectOptions = document.getElementById('language-select-options');
         // State
         let isPlaying = false;
         let currentStationIndex = -1;
@@ -1357,7 +1364,15 @@
         const YOUTUBE_API_KEY = 'AIzaSyBwphUWyr9U0Eb8gsLN67ojZDA_rOHU3TA'; // WARNING: This is a public key, do not use in production without a backend proxy.
         // NEWS API KEY - NEW
         const NEWS_API_KEY = '7446c8e28d503d82c84577c80c13c8fc';
-        const RADIO_STATIONS_URL = 'https://raw.githubusercontent.com/simsonpeter/Tcradios/main/stations.json';
+        // Language station file map - NEW
+        const LANGUAGE_FILES = {
+            'Dutch': 'https://raw.githubusercontent.com/simsonpeter/Tcradios/refs/heads/main/languages/dutch.json',
+            'English': 'https://raw.githubusercontent.com/simsonpeter/Tcradios/refs/heads/main/languages/english.json',
+            'Hindi': 'https://raw.githubusercontent.com/simsonpeter/Tcradios/refs/heads/main/languages/hindi.json',
+            'Malayalam': 'https://raw.githubusercontent.com/simsonpeter/Tcradios/refs/heads/main/languages/malayalam.json',
+            'Sinhala': 'https://raw.githubusercontent.com/simsonpeter/Tcradios/refs/heads/main/languages/sinhala.json'
+        };
+        let selectedLanguage = localStorage.getItem('selectedLanguage') || 'English';
         let touchStartY = 0;
         let isSwiping = false;
         // Calendar State
@@ -1375,7 +1390,8 @@
         // Initialize function
         function init() {
             updateClock();
-            loadRadioStations();
+            populateLanguageDropdown();
+            loadStationsForLanguage(selectedLanguage);
             getWeather(currentCity);
             setupEventListeners();
             loadYouTubeAPI();
@@ -1527,9 +1543,25 @@
             }
         }
         // Radio functions
-        async function loadRadioStations() {
+        function populateLanguageDropdown() {
+            languageSelectOptions.innerHTML = '';
+            Object.keys(LANGUAGE_FILES).forEach(languageName => {
+                const option = document.createElement('div');
+                option.className = 'radio-dropdown-option';
+                option.textContent = languageName;
+                option.addEventListener('click', () => selectLanguage(languageName));
+                languageSelectOptions.appendChild(option);
+            });
+            languageSelectBtn.innerHTML = `${selectedLanguage} <i class="fas fa-chevron-up"></i>`;
+        }
+
+        async function loadStationsForLanguage(languageName) {
             try {
-                const response = await fetch(RADIO_STATIONS_URL);
+                const url = LANGUAGE_FILES[languageName];
+                if (!url) {
+                    throw new Error('Language file URL not found');
+                }
+                const response = await fetch(url);
                 if (!response.ok) {
                     throw new Error(`HTTP error! status: ${response.status}`);
                 }
@@ -1544,14 +1576,25 @@
                     option.addEventListener('click', () => selectStation(index));
                     stationSelectOptions.appendChild(option);
                 });
-                // Select first station by default
                 if (radioStations.length > 0) {
                     selectStation(0);
+                } else {
+                    currentStationName.textContent = 'No stations available';
+                    stationIcon.style.display = 'none';
                 }
             } catch (error) {
-                console.error('Error loading radio stations:', error);
-                showNotification('Failed to load radio stations', 'error');
+                console.error('Error loading stations for language:', error);
+                showNotification('Failed to load stations for selected language', 'error');
             }
+        }
+
+        function selectLanguage(languageName) {
+            selectedLanguage = languageName;
+            localStorage.setItem('selectedLanguage', selectedLanguage);
+            languageSelectBtn.innerHTML = `${selectedLanguage} <i class="fas fa-chevron-up"></i>`;
+            languageSelectOptions.style.display = 'none';
+            loadStationsForLanguage(selectedLanguage);
+            showNotification(`Selected language: ${selectedLanguage}`, 'info');
         }
         function selectStation(index) {
             currentStationIndex = index;
@@ -2329,10 +2372,19 @@
                 stationSelectOptions.style.display = isOptionsVisible ? 'none' : 'block';
                 stationSelectBtn.querySelector('i').className = isOptionsVisible ? 'fas fa-chevron-up' : 'fas fa-chevron-down';
             });
+            // Language dropdown toggle - NEW
+            languageSelectBtn.addEventListener('click', (e) => {
+                e.stopPropagation();
+                const isOptionsVisible = languageSelectOptions.style.display === 'block';
+                languageSelectOptions.style.display = isOptionsVisible ? 'none' : 'block';
+                languageSelectBtn.querySelector('i').className = isOptionsVisible ? 'fas fa-chevron-up' : 'fas fa-chevron-down';
+            });
             document.addEventListener('click', (e) => {
                 if (!e.target.closest('.radio-dropdown')) {
                     stationSelectOptions.style.display = 'none';
+                    languageSelectOptions.style.display = 'none';
                     stationSelectBtn.querySelector('i').className = 'fas fa-chevron-up';
+                    languageSelectBtn.querySelector('i').className = 'fas fa-chevron-up';
                 }
             });
             youtubeSearchBtn.addEventListener('click', searchYouTube);


### PR DESCRIPTION
Add a language selector to the radio dashboard to enable switching between language-specific station streams while maintaining the existing UI size.

---
<a href="https://cursor.com/background-agent?bcId=bc-73638cfd-81d0-4d21-81c7-f53721517f74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-73638cfd-81d0-4d21-81c7-f53721517f74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

