### PR TITLE
Change dropdowns to drop ups

### DIFF
--- a/index.html
+++ b/index.html
@@ -513,15 +513,15 @@
         }
         .radio-dropdown-options {
             position: absolute;
-            top: 100%;
+            bottom: 100%;
             left: 0;
             width: 100%;
             background-color: var(--card-bg);
             border-radius: 6px;
-            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+            box-shadow: 0 -4px 6px rgba(0, 0, 0, 0.1);
             max-height: 120px;
             overflow-y: auto;
-            margin-top: 5px;
+            margin-bottom: 5px;
             z-index: 9999;
             display: none;
         }

--- a/index3.html
+++ b/index3.html
@@ -513,16 +513,16 @@
         }
         .radio-dropdown-options {
             position: absolute;
-            top: 100%; /* Opens downward */
-            bottom: auto;
+            bottom: 100%; /* Opens upward */
+            top: auto;
             left: 0;
             width: 100%;
             background-color: var(--card-bg);
             border-radius: 6px;
-            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+            box-shadow: 0 -4px 6px rgba(0, 0, 0, 0.1);
             max-height: 120px;
             overflow-y: auto;
-            margin-top: 5px; /* Space between button and dropdown */
+            margin-bottom: 5px; /* Space between button and dropdown */
             z-index: 50;
             display: none;
             /* --- DEBUG BORDER --- */
@@ -1160,11 +1160,11 @@
                             <!-- MODIFIED: Simplified Language Dropdown -->
                             <div class="radio-dropdown">
                                 <button id="language-select-btn" class="radio-dropdown-btn">Select Language <i class="fas fa-chevron-down"></i></button>
-                                <div id="language-select-options" class="radio-dropdown-options" style="top: 100%;"></div>
+                                <div id="language-select-options" class="radio-dropdown-options" style="bottom: 100%;"></div>
                             </div>
                             <div class="radio-dropdown">
                                 <button id="station-select-btn" class="radio-dropdown-btn">Select Station <i class="fas fa-chevron-down"></i></button>
-                                <div id="station-select-options" class="radio-dropdown-options" style="top: 100%;"></div>
+                                <div id="station-select-options" class="radio-dropdown-options" style="bottom: 100%;"></div>
                             </div>
                         </div>
                     </section>


### PR DESCRIPTION
Make both language and station dropdowns open upward instead of downward by adjusting CSS positioning and box-shadow.

---
<a href="https://cursor.com/background-agent?bcId=bc-a7c8a10a-140b-406d-a2d7-5606400536fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a7c8a10a-140b-406d-a2d7-5606400536fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

