### PR TITLE
Investigate missing dropdown items

### DIFF
--- a/index.html
+++ b/index.html
@@ -1706,6 +1706,14 @@
             } catch (error) {
                 console.error('Error loading stations for language:', error);
                 showNotification('Failed to load stations for selected language', 'error');
+                // Fallback UI so the dropdown is not empty
+                radioStations = [];
+                rebuildStationDropdown();
+                if (stationSelectOptions) {
+                    stationSelectOptions.innerHTML = '<div class="radio-dropdown-option" style="pointer-events:none; opacity:0.7;">Unable to load stations. Check network.</div>';
+                }
+                if (currentStationName) currentStationName.textContent = 'No stations available';
+                if (stationIcon) stationIcon.style.display = 'none';
             }
         }
 

--- a/index3.html
+++ b/index3.html
@@ -1422,16 +1422,21 @@
 
         function populateLanguageDropdown() {
             languageSelectOptions.innerHTML = '';
-            Object.keys(LANGUAGE_FILES).forEach((languageName) => {
-                const option = document.createElement('div');
-                option.className = 'radio-dropdown-option';
-                option.textContent = languageName;
-                option.dataset.language = languageName;
-                option.addEventListener('click', () => {
-                    selectLanguage(languageName);
+            const languageNames = Object.keys(LANGUAGE_FILES || {});
+            if (languageNames.length === 0) {
+                languageSelectOptions.innerHTML = '<div class="radio-dropdown-option" style="pointer-events:none; opacity:0.7;">No languages available</div>';
+            } else {
+                languageNames.forEach((languageName) => {
+                    const option = document.createElement('div');
+                    option.className = 'radio-dropdown-option';
+                    option.textContent = languageName;
+                    option.dataset.language = languageName;
+                    option.addEventListener('click', () => {
+                        selectLanguage(languageName);
+                    });
+                    languageSelectOptions.appendChild(option);
                 });
-                languageSelectOptions.appendChild(option);
-            });
+            }
             languageSelectBtn.innerHTML = `${currentLanguage} <i class="fas fa-chevron-up"></i>`;
         }
 
@@ -1476,6 +1481,14 @@
                 }
             } catch (err) {
                 console.error('Failed to load stations for language', languageName, err);
+                // Fallback UI so the dropdown is not empty
+                radioStations = [];
+                populateStationDropdown();
+                if (stationSelectOptions) {
+                    stationSelectOptions.innerHTML = '<div class="radio-dropdown-option" style="pointer-events:none; opacity:0.7;">Unable to load stations. Check network.</div>';
+                }
+                if (currentStationName) currentStationName.textContent = 'No stations available';
+                if (stationIcon) stationIcon.style.display = 'none';
             }
         }
 


### PR DESCRIPTION
Add resilient fallbacks to language and station dropdowns to prevent them from appearing empty when data fails to load.

The dropdowns previously rendered blank if the external JSON fetch for station data failed (e.g., due to network issues, being offline, or CORS blocks), leading to a poor user experience. This change ensures a helpful message is displayed instead.

---
<a href="https://cursor.com/background-agent?bcId=bc-7f7c59cc-8a10-4b9d-bfd8-b4774cfc0ba7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7f7c59cc-8a10-4b9d-bfd8-b4774cfc0ba7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

